### PR TITLE
Allow simultaneous multi-version builds (`el9`)

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -2,20 +2,67 @@
 name: Build Image / RPM(s)
 
 inputs:
+  download_rpms:
+    description: Download RPMS
+    required: false
   image_prefix:
+    default: ghcr.io/${{ github.repository }}/
     description: Image Prefix
-    required: true
+    required: false
+  image_registry:
+    default: ghcr.io
+    description: Image Registry
+    required: false
   make_target:
     description: Make target
     required: true
+  push_image:
+    description: Push image
+    required: false
 
 runs:
   using: composite
 
   steps:
+    - name: Download RPMS directory
+      if: inputs.download_rpms
+      uses: actions/download-artifact@v3
+      with:
+        name: RPMS
+        path: RPMS
+
+    - name: Get list of pre-existing RPMs
+      if: inputs.download_rpms
+      run: |
+        echo "RPMS=$(find RPMS -type f -name *.rpm | xargs)" >> $GITHUB_ENV
+      shell: bash --noprofile --norc -euxo pipefail {0}
+
+    - name: Log in to GHCR
+      uses: ./.github/actions/docker/registry-login
+      with:
+        server: ${{ inputs.image_registry }}
+
     - name: Build Image / RPM(s)
       env:
         IMAGE_PREFIX: ${{ inputs.image_prefix }}
       run: |
         make ${{ inputs.make_target }}
       shell: bash --noprofile --norc -euxo pipefail {0}
+
+    - name: Push `${{ matrix.image }}` to GHCR
+      if: inputs.push_image
+      run: |
+        docker-compose push ${{ matrix.image }}
+      shell: bash --noprofile --norc -euxo pipefail {0}
+
+    - name: Remove pre-existing RPMs
+      if: inputs.download_rpms
+      run: |
+        rm --force --verbose ${RPMS}
+      shell: bash --noprofile --norc -euxo pipefail {0}
+
+    - name: Upload RPMS directory
+      uses: actions/upload-artifact@v3
+      with:
+        name: RPMS
+        path: RPMS

--- a/.github/workflows/ci.el9.yml
+++ b/.github/workflows/ci.el9.yml
@@ -1,13 +1,13 @@
 ---
-name: CI
+name: CI (EL9)
 
 on:
   - push
 
 env:
   DOCKER_BUILDKIT: 1
-  IMAGE_PREFIX: ghcr.io/${{ github.repository }}/
-  IMAGE_REGISTRY: ghcr.io
+  IMAGE_PREFIX: ghcr.io/${{ github.repository }}/el9/
+  PACKAGE_PREFIX: geoint-apps%2Fel9%2F
 
 jobs:
   build-images:
@@ -29,24 +29,17 @@ jobs:
       - name: Delete old images
         uses: ./.github/actions/github-api/delete-package
         with:
-          package_name: geoint-apps%2F${{ matrix.image }}
+          package_name: ${{ env.PACKAGE_PREFIX }}${{ matrix.image }}
           token: ${{ secrets.PKG_DELETE_TOKEN }}
           token_type: token
-
-      - name: Log in to GHCR
-        uses: ./.github/actions/docker/registry-login
-        with:
-          server: ${{ env.IMAGE_REGISTRY }}
 
       - name: Build `${{ matrix.image }}` Image
         uses: ./.github/actions/build
         with:
           image_prefix: ${{ env.IMAGE_PREFIX }}
           make_target: ${{ matrix.image }}
+          push_image: true
 
-      - name: Push `${{ matrix.image }}` to GHCR
-        run: |
-          docker-compose push ${{ matrix.image }}
 
   build-rpms:
     name: Build `${{ matrix.rpm }}` RPM(s)
@@ -69,23 +62,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Log in to GHCR
-        uses: ./.github/actions/docker/registry-login
-        with:
-          server: ${{ env.IMAGE_REGISTRY }}
-
       - name: Build `${{ matrix.rpm }}` RPM(s)
         uses: ./.github/actions/build
         with:
           image_prefix: ${{ env.IMAGE_PREFIX }}
           make_target: ${{ matrix.rpm }}
 
-      - name: Upload RPMS directory
-        uses: actions/upload-artifact@v3
-        with:
-          name: RPMS
-          path: RPMS
-          retention-days: 1
 
   create-and-push-repo:
     name: Create & push repository

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # FoundationGEOINT Applications
 
-[![CI](https://github.com/radiant-maxar/geoint-apps/actions/workflows/ci.yml/badge.svg)](https://github.com/radiant-maxar/geoint-apps/actions/workflows/ci.yml)
+[![CI](https://github.com/radiant-maxar/geoint-apps/actions/workflows/ci.el9.yml/badge.svg)](https://github.com/radiant-maxar/geoint-apps/actions/workflows/ci.el9.yml)
 
 This repository provides a Docker-based build system for creating
 RPMs of the latest geospatial libraries on CentOS/RHEL 7 until the


### PR DESCRIPTION
Currently the package names (I.E. image names) don't differentiate between `el7` & `el9` for base images.