### PR TITLE
OSRM Users (EL9)

### DIFF
--- a/SPECS/el9/osrm-backend.spec
+++ b/SPECS/el9/osrm-backend.spec
@@ -1,3 +1,7 @@
+%global osrm_backend_home %{_sharedstatedir}/osrm-backend
+%global osrm_backend_uid 547
+%global osrm_backend_user osrm-backend
+
 # Force CMake to use `build` for its directory, tests assume it.
 %global _vpath_builddir build
 
@@ -79,6 +83,7 @@ npm install
 
 %install
 %{cmake_install}
+%{__install} -d -m 0750 %{buildroot}%{osrm_backend_home}
 
 
 %check
@@ -115,18 +120,38 @@ popd
 
 
 %files
+%doc README.md CHANGELOG.md
+%license LICENSE.TXT
 %{_bindir}/osrm-*
 %{_libdir}/*.so
 %{_datadir}/osrm/profiles
-%doc README.md CHANGELOG.md
-%license LICENSE.TXT
-
+%defattr(-, %{osrm_backend_user}, %{osrm_backend_user}, -)
+%dir %{osrm_backend_home}
 
 %files devel
 %{_includedir}/flatbuffers
 %{_includedir}/mapbox
 %{_includedir}/osrm
 %{_libdir}/pkgconfig/libosrm.pc
+
+
+%pre
+%{_bindir}/getent group %{osrm_backend_user} >/dev/null || \
+    %{_sbindir}/groupadd \
+        --force \
+        --gid %{osrm_backend_uid} \
+        --system \
+        %{osrm_backend_user}
+
+%{_bindir}/getent passwd %{osrm_backend_user} >/dev/null || \
+    %{_sbindir}/useradd \
+        --uid %{osrm_backend_uid} \
+        --gid %{osrm_backend_user} \
+        --comment "OSRM Backend User" \
+        --shell /sbin/nologin \
+        --home-dir %{osrm_backend_home} \
+        --system \
+        %{osrm_backend_user}
 
 
 %changelog

--- a/SPECS/el9/osrm-frontend.spec
+++ b/SPECS/el9/osrm-frontend.spec
@@ -1,5 +1,6 @@
-# The following macros are also required:
-%global nodejs_min_version 18.0.0
+%global osrm_frontend_home %{_datadir}/osrm-frontend
+%global osrm_frontend_uid 551
+%global osrm_frontend_user osrm-frontend
 
 %global __brp_mangle_shebangs /usr/bin/true
 
@@ -14,12 +15,9 @@ URL:            https://map.project-osrm.org
 Source0:        https://github.com/Project-OSRM/osrm-frontend/archive/%{git_ref}/osrm-frontend-%{git_ref}.tar.gz
 
 BuildArch:      noarch
-BuildRequires:  nodejs-devel >= %{nodejs_min_version}
+BuildRequires:  nodejs-devel
 
-Requires:       nodejs >= %{nodejs_min_version}
-%if 0%{?rhel} >= 8
-Requires: npm
-%endif
+Requires:       nodejs
 
 
 %description
@@ -36,7 +34,8 @@ npm run build
 
 
 %install
-%{__install} -d %{buildroot}%{_datadir}/%{name}
+%{__install} -d %{buildroot}%{osrm_frontend_home}
+%{__install} -d -m 0750 %{buildroot}%{osrm_frontend_home}/.npm
 %{__cp} -rp \
    bundle.js \
    css \
@@ -51,45 +50,64 @@ npm run build
    package-lock.json \
    scripts \
    src \
-   %{buildroot}%{_datadir}/%{name}
-touch %{buildroot}%{_datadir}/%{name}/bundle.{js.map,raw.js}
+   %{buildroot}%{osrm_frontend_home}
+touch %{buildroot}%{osrm_frontend_home}/bundle.{js.map,raw.js}
 
 
 %files
 %doc README.md
 %license LICENSE
-%{_datadir}/%{name}/css/fonts.css
-%{_datadir}/%{name}/css/site.css
-%{_datadir}/%{name}/debug/arrows*
-%{_datadir}/%{name}/debug/dist
-%{_datadir}/%{name}/favicon.ico
-%{_datadir}/%{name}/fonts
-%{_datadir}/%{name}/i18n
-%{_datadir}/%{name}/images
-%{_datadir}/%{name}/index.html
-%{_datadir}/%{name}/node_modules
-%{_datadir}/%{name}/package.json
-%{_datadir}/%{name}/package-lock.json
-%{_datadir}/%{name}/scripts
-%{_datadir}/%{name}/src/geocoder.js
-%{_datadir}/%{name}/src/index.js
-%{_datadir}/%{name}/src/itinerary_builder.js
-%{_datadir}/%{name}/src/links.js
-%{_datadir}/%{name}/src/localization.js
-%{_datadir}/%{name}/src/lrm_options.js
-%{_datadir}/%{name}/src/polyfill.js
-%{_datadir}/%{name}/src/state.js
-%{_datadir}/%{name}/src/tools.js
-%{_datadir}/%{name}/src/libs
-# These files need to owned by an unprivileged user, so it may recompile
-# with new settings.
-%defattr(-,nobody,nobody)
-%{_datadir}/%{name}/bundle.js
-%{_datadir}/%{name}/bundle.js.map
-%{_datadir}/%{name}/bundle.raw.js
-%{_datadir}/%{name}/css/leaflet.css
-%{_datadir}/%{name}/debug/index.html
-%{_datadir}/%{name}/src/leaflet_options.js
+%{osrm_frontend_home}/css/fonts.css
+%{osrm_frontend_home}/css/site.css
+%{osrm_frontend_home}/debug/arrows*
+%{osrm_frontend_home}/debug/dist
+%{osrm_frontend_home}/favicon.ico
+%{osrm_frontend_home}/fonts
+%{osrm_frontend_home}/i18n
+%{osrm_frontend_home}/images
+%{osrm_frontend_home}/index.html
+%{osrm_frontend_home}/node_modules
+%{osrm_frontend_home}/package.json
+%{osrm_frontend_home}/package-lock.json
+%{osrm_frontend_home}/scripts
+%{osrm_frontend_home}/src/geocoder.js
+%{osrm_frontend_home}/src/index.js
+%{osrm_frontend_home}/src/itinerary_builder.js
+%{osrm_frontend_home}/src/links.js
+%{osrm_frontend_home}/src/localization.js
+%{osrm_frontend_home}/src/lrm_options.js
+%{osrm_frontend_home}/src/polyfill.js
+%{osrm_frontend_home}/src/state.js
+%{osrm_frontend_home}/src/tools.js
+%{osrm_frontend_home}/src/libs
+# These files need to owned by osrm-frontend, so it may recompile with new settings.
+%defattr(-,%{osrm_frontend_user},%{osrm_frontend_user})
+%dir %{osrm_frontend_home}/.npm
+%{osrm_frontend_home}/bundle.js
+%{osrm_frontend_home}/bundle.js.map
+%{osrm_frontend_home}/bundle.raw.js
+%{osrm_frontend_home}/css/leaflet.css
+%{osrm_frontend_home}/debug/index.html
+%{osrm_frontend_home}/src/leaflet_options.js
+
+
+%pre
+%{_bindir}/getent group %{osrm_frontend_user} >/dev/null || \
+    %{_sbindir}/groupadd \
+        --force \
+        --gid %{osrm_frontend_uid} \
+        --system \
+        %{osrm_frontend_user}
+
+%{_bindir}/getent passwd %{osrm_frontend_user} >/dev/null || \
+    %{_sbindir}/useradd \
+        --uid %{osrm_frontend_uid} \
+        --gid %{osrm_frontend_user} \
+        --comment "OSRM Frontend User" \
+        --shell /sbin/nologin \
+        --home-dir %{osrm_frontend_home} \
+        --system \
+        %{osrm_frontend_user}
 
 
 %changelog


### PR DESCRIPTION
* Create distinct `osrm-backend` and `osrm-frontend` daemon users instead of using `nobody` (uid changes from 99 to 65534 in EL9).
* No need for NodeJS requirement restrictions after EL7.
* Later versions of NPM require `~/.npm` to exist.