### PR TITLE
Upgrade Nominatim UI from 3.2.4 to 3.2.6

### DIFF
--- a/SOURCES/el7/nominatim-ui-test-vaduz-name-keyword.patch
+++ b/SOURCES/el7/nominatim-ui-test-vaduz-name-keyword.patch
@@ -1,0 +1,13 @@
+diff --git a/test/details.js b/test/details.js
+index e543496..553929b 100644
+--- a/test/details.js
++++ b/test/details.js
+@@ -83,7 +83,7 @@ describe('Details Page', function () {
+         assert.deepStrictEqual(display_headers, ['Name Keywords', 'Address Keywords']);
+ 
+         let page_content = await page.$eval('body', el => el.textContent);
+-        assert.ok(page_content.includes('qwaansshe')); // one of the name keywords
++        assert.ok(page_content.includes('vaduzo')); // one of the name keywords
+       });
+     }
+ 

--- a/SOURCES/el9/nominatim-ui-test-vaduz-name-keyword.patch
+++ b/SOURCES/el9/nominatim-ui-test-vaduz-name-keyword.patch
@@ -1,0 +1,13 @@
+diff --git a/test/details.js b/test/details.js
+index e543496..553929b 100644
+--- a/test/details.js
++++ b/test/details.js
+@@ -83,7 +83,7 @@ describe('Details Page', function () {
+         assert.deepStrictEqual(display_headers, ['Name Keywords', 'Address Keywords']);
+ 
+         let page_content = await page.$eval('body', el => el.textContent);
+-        assert.ok(page_content.includes('qwaansshe')); // one of the name keywords
++        assert.ok(page_content.includes('vaduzo')); // one of the name keywords
+       });
+     }
+ 

--- a/SPECS/el7/nominatim-ui.spec
+++ b/SPECS/el7/nominatim-ui.spec
@@ -14,10 +14,9 @@ Release:        %{rpmbuild_release}%{?dist}
 Summary:        Debug web interface for Nominatim
 License:        GPLv2
 URL:            https://github.com/osm-search/nominatim-ui
-
 Source0:        https://github.com/osm-search/nominatim-ui/archive/v%{version}/nominatim-ui-%{version}.tar.gz
-
 Patch0:         nominatim-ui-test-browser-no-sandbox.patch
+Patch1:         nominatim-ui-test-vaduz-name-keyword.patch
 
 BuildArch:      noarch
 

--- a/SPECS/el9/nominatim-ui.spec
+++ b/SPECS/el9/nominatim-ui.spec
@@ -16,6 +16,7 @@ License:        GPLv2
 URL:            https://github.com/osm-search/nominatim-ui
 Source0:        https://github.com/osm-search/nominatim-ui/archive/v%{version}/nominatim-ui-%{version}.tar.gz
 Patch0:         nominatim-ui-test-browser-no-sandbox.patch
+Patch1:         nominatim-ui-test-vaduz-name-keyword.patch
 
 BuildArch:      noarch
 

--- a/docker-compose.el7.yml
+++ b/docker-compose.el7.yml
@@ -35,7 +35,7 @@ x-rpmbuild:
       version: &nominatim_version 4.0.1-2
     nominatim-ui:
       image: rpmbuild-nominatim-ui
-      version: &nominatim_ui_version 3.2.4-1
+      version: &nominatim_ui_version 3.2.6-1
     osrm-backend:
       image: rpmbuild-osrm-backend
       version: &osrm_backend_version 5.26.0-1

--- a/docker-compose.el9.yml
+++ b/docker-compose.el9.yml
@@ -35,7 +35,7 @@ x-rpmbuild:
       version: &nominatim_version 4.0.1-1
     nominatim-ui:
       image: rpmbuild-nominatim-ui
-      version: &nominatim_ui_version 3.2.4-1
+      version: &nominatim_ui_version 3.2.6-1
     osrm-backend:
       image: rpmbuild-osrm-backend
       version: &osrm_backend_version 5.26.0-1


### PR DESCRIPTION
And fix test failure:

* `qwaansshe` is no longer listed as a name keyword for `Vaduz`:
  * https://nominatim.openstreetmap.org/ui/details.html?osmtype=R&osmid=1155956&keywords=1