### PR TITLE
Use v1.1 actions

### DIFF
--- a/.github/workflows/ci.el7.yml
+++ b/.github/workflows/ci.el7.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Delete old images
-        uses: radiant-maxar/geoint-actions/github-api/delete-package@v1
+        uses: radiant-maxar/geoint-actions/github-api/delete-package@v1.1
         with:
           el_version: ${{ env.EL_VERSION }}
           package_name: ${{ matrix.image }}
@@ -35,11 +35,12 @@ jobs:
           token_type: token
 
       - name: Build `${{ matrix.image }}` Image
-        uses: radiant-maxar/geoint-actions/build@v1
+        uses: radiant-maxar/geoint-actions/build@v1.1
         with:
           el_version: ${{ env.EL_VERSION }}
           make_target: ${{ matrix.image }}
           push_image: true
+          upload_rpms: false
 
 
   build-rpms:
@@ -64,7 +65,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Build `${{ matrix.rpm }}` RPM(s)
-        uses: radiant-maxar/geoint-actions/build@v1
+        uses: radiant-maxar/geoint-actions/build@v1.1
         with:
           el_version: ${{ env.EL_VERSION }}
           make_target: ${{ matrix.rpm }}
@@ -80,19 +81,20 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Download RPMS directory
-        uses: actions/download-artifact@v3
+      - name: Download RPMS artifact
+        uses: radiant-maxar/geoint-actions/artifact/download@v1.1
         with:
-          name: RPMS-${{ env.EL_VERSION }}-${{ github.sha }}
-          path: RPMS
+          base_path: .
+          directory: RPMS
+          el_version: ${{ env.EL_VERSION }}
 
       - name: Create repository
-        uses: radiant-maxar/geoint-actions/repository/create@v1
+        uses: radiant-maxar/geoint-actions/repository/create@v1.1
         with:
           el_version: ${{ env.EL_VERSION }}
 
       - name: Upload repository
-        uses: radiant-maxar/geoint-actions/repository/upload@v1
+        uses: radiant-maxar/geoint-actions/repository/upload@v1.1
         with:
           aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/ci.el9.yml
+++ b/.github/workflows/ci.el9.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Delete old images
-        uses: radiant-maxar/geoint-actions/github-api/delete-package@v1
+        uses: radiant-maxar/geoint-actions/github-api/delete-package@v1.1
         with:
           el_version: ${{ env.EL_VERSION }}
           package_name: ${{ matrix.image }}
@@ -34,11 +34,12 @@ jobs:
           token_type: token
 
       - name: Build `${{ matrix.image }}` Image
-        uses: radiant-maxar/geoint-actions/build@v1
+        uses: radiant-maxar/geoint-actions/build@v1.1
         with:
           el_version: ${{ env.EL_VERSION }}
           make_target: ${{ matrix.image }}
           push_image: true
+          upload_rpms: false
 
 
   build-rpms:
@@ -63,7 +64,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Build `${{ matrix.rpm }}` RPM(s)
-        uses: radiant-maxar/geoint-actions/build@v1
+        uses: radiant-maxar/geoint-actions/build@v1.1
         with:
           el_version: ${{ env.EL_VERSION }}
           make_target: ${{ matrix.rpm }}
@@ -79,19 +80,20 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Download RPMS directory
-        uses: actions/download-artifact@v3
+      - name: Download RPMS artifact
+        uses: radiant-maxar/geoint-actions/artifact/download@v1.1
         with:
-          name: RPMS-${{ env.EL_VERSION }}-${{ github.sha }}
-          path: RPMS
+          base_path: .
+          directory: RPMS
+          el_version: ${{ env.EL_VERSION }}
 
       - name: Create repository
-        uses: radiant-maxar/geoint-actions/repository/create@v1
+        uses: radiant-maxar/geoint-actions/repository/create@v1.1
         with:
           el_version: ${{ env.EL_VERSION }}
 
       - name: Upload repository
-        uses: radiant-maxar/geoint-actions/repository/upload@v1
+        uses: radiant-maxar/geoint-actions/repository/upload@v1.1
         with:
           aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
This adds the repository name to the filenames so that you know more about the artifact you downloaded, helpful since `geoint-deps` files otherwise have about the same names.

https://github.com/radiant-maxar/geoint-actions/compare/v1...v1.1

**I.E.**:
_Before_:
`RPMS-el7-b84b6a3fb8e4498726b8d0e7f5cfd913cb9d8990.zip`
&
`RPMS-el9-b84b6a3fb8e4498726b8d0e7f5cfd913cb9d8990.zip`

_After_:
`RPMS.geoint-apps.el7.4c42941e316bc64f2ad7a11c71185165ccb88a7d.zip`
&
`RPMS.geoint-apps.el9.4c42941e316bc64f2ad7a11c71185165ccb88a7d.zip`