### PR TITLE
Nominatim on EL9 with PostgreSQL 15

### DIFF
--- a/SOURCES/el9/nominatim-tests-run-serial.patch
+++ b/SOURCES/el9/nominatim-tests-run-serial.patch
@@ -8,8 +8,8 @@ index 02c290cc..c46e1ecd 100644
          endforeach()
 +        # Do not run "bdd_{api,db,osm2pgsql}" in parallel with any other test.
 +        set_tests_properties(bdd_api PROPERTIES RUN_SERIAL TRUE)
-+        #set_tests_properties(bdd_db PROPERTIES RUN_SERIAL TRUE)
-+        #set_tests_properties(bdd_osm2pgsql PROPERTIES RUN_SERIAL TRUE)
++        set_tests_properties(bdd_db PROPERTIES RUN_SERIAL TRUE)
++        set_tests_properties(bdd_osm2pgsql PROPERTIES RUN_SERIAL TRUE)
      else()
          message(WARNING "behave not found. BDD tests disabled." )
      endif()

--- a/SPECS/el9/nominatim.spec
+++ b/SPECS/el9/nominatim.spec
@@ -148,10 +148,6 @@ export PATH=${HOME}/.local/bin:${PATH}
 %{__cp} -p %{SOURCE1} data/country_osm_grid.sql.gz
 %{__cp} -p %{SOURCE2} %{SOURCE3} data
 
-# XXX: The BDD db/osm2pgsql tests have issues with PostgreSQL 15, disable
-#      pending further investigation.
-%{__sed} -i -e 's/db osm2pgsql //' CMakeLists.txt
-
 %cmake -DBUILD_API:BOOL=ON \
        -DBUILD_IMPORTER:BOOL=ON \
        -DBUILD_OSM2PGSQL:BOOL=OFF \
@@ -268,8 +264,7 @@ export PYTHONPATH=${HOME}/.local/lib/python%{python3_version}/site-packages:%{py
 %{__sed} -i -e 's/^disable=.*$/disable=arguments-differ,arguments-renamed,consider-using-f-string,consider-using-generator,consider-using-with,duplicate-code,redundant-u-string-prefix,too-few-public-methods,unspecified-encoding,use-dict-literal/' .pylintrc
 echo "max-statements=100" >> .pylintrc
 
-# Invoke testing/linting runner using a single process.
-%global _smp_ncpus_max 1
+# Invoke testing/linting runner
 %ctest
 
 # Clean up.


### PR DESCRIPTION
Builds successfully on my system and here.

```shell
+ /usr/bin/ctest --output-on-failure --force-new-ctest-process -j12
Test project /rpmbuild/BUILD/Nominatim-4.0.1/build
    Start 1: bdd_db
1/7 Test #1: bdd_db ...........................   Passed  694.89 sec
    Start 2: bdd_osm2pgsql
2/7 Test #2: bdd_osm2pgsql ....................   Passed   32.23 sec
    Start 3: bdd_api
3/7 Test #3: bdd_api ..........................   Passed   85.81 sec
    Start 4: php
    Start 5: phpcs
    Start 6: pylint
    Start 7: pytest
4/7 Test #4: php ..............................   Passed    0.60 sec
5/7 Test #5: phpcs ............................   Passed    1.66 sec
6/7 Test #6: pylint ...........................   Passed   15.35 sec
7/7 Test #7: pytest ...........................   Passed  306.99 sec

100% tests passed, 0 tests failed out of 7

Total Test time (real) = 1119.96 sec
```

Re-enabled `RUN_SERIAL` setting for previously disabled tests.