### PR TITLE
Upgrade Overpass API from v0.7.59 to v0.7.59.1 (EL9)

### DIFF
--- a/SOURCES/el9/overpass-api-environment-settings.patch
+++ b/SOURCES/el9/overpass-api-environment-settings.patch
@@ -12,8 +12,8 @@ index 81a1d2a2..320c5d59 100644
  #include <sstream>
 @@ -101,6 +102,8 @@ Basic_Settings::Basic_Settings()
    shared_name_base("/osm3s_v0.7.58"),
-   version("0.7.59"),
-   source_hash("e21c39febb0606a38d7fead087456ff6c3a0dba4"),
+   version("0.7.59.1"),
+   source_hash("2a9d9642eaa7775a716166f1b9fc564e60c06b84"),
 +  enclave(getenv("OVERPASS_API_ENCLAVE") ? getenv("OVERPASS_API_ENCLAVE") : "www.openstreetmap.org"),
 +  generator_note(getenv("OVERPASS_API_GENERATOR_NOTE") ? getenv("OVERPASS_API_GENERATOR_NOTE") : ""),
  #ifdef HAVE_LZ4

--- a/docker-compose.el9.yml
+++ b/docker-compose.el9.yml
@@ -46,7 +46,7 @@ x-rpmbuild:
       version: &osrm_frontend_version 2021.9.30-1
     overpass-api:
       image: rpmbuild-overpass-api
-      version: &overpass_api_version 0.7.59-1
+      version: &overpass_api_version 0.7.59.1-1
     taginfo:
       defines:
         abseil_git_ref: 384a25d5e19228ceb7641676aefd58c4ca7a9568


### PR DESCRIPTION
Not a big release, but it looks like the few minor improvements there are might be helpful for us.
https://github.com/drolbr/Overpass-API/compare/osm3s-v0.7.59...osm3s-v0.7.59.1