### PR TITLE
Update nominatim-data source URLs

### DIFF
--- a/SPECS/el7/nominatim.spec
+++ b/SPECS/el7/nominatim.spec
@@ -30,9 +30,11 @@ License:        GPLv2
 URL:            https://nominatim.org/
 
 Source0:        https://github.com/openstreetmap/Nominatim/archive/v%{version}/Nominatim-%{version}.tar.gz
-Source1:        https://www.nominatim.org/data/country_grid.sql.gz
-Source2:        https://www.nominatim.org/data/gb_postcode_data.sql.gz
-Source3:        https://www.nominatim.org/data/us_postcode_data.sql.gz
+# Archive.org is used since data downloads now require a custom user agent
+# https://github.com/osm-search/Nominatim/issues/2929
+Source1:        https://web.archive.org/web/%{data_archive_snapshot}/https://nominatim.org/data/country_grid.sql.gz
+Source2:        https://web.archive.org/web/%{data_archive_snapshot}/https://nominatim.org/data/gb_postcode_data.sql.gz
+Source3:        https://web.archive.org/web/%{data_archive_snapshot}/https://nominatim.org/data/us_postcode_data.sql.gz
 %if %{with tests}
 Source4:        https://download.geofabrik.de/europe/monaco-latest.osm.pbf
 %endif

--- a/SPECS/el9/nominatim-requirements.txt
+++ b/SPECS/el9/nominatim-requirements.txt
@@ -1,6 +1,4 @@
-behave==1.2.6
 datrie==0.8.2
 Cython==0.29.32
 pytidylib==0.3.2
-pylint==2.15.5
 PyICU==2.10.2

--- a/SPECS/el9/nominatim.spec
+++ b/SPECS/el9/nominatim.spec
@@ -30,9 +30,11 @@ License:        GPLv2
 URL:            https://github.com/openstreetmap/Nominatim
 
 Source0:        https://github.com/openstreetmap/Nominatim/archive/v%{version}/Nominatim-%{version}.tar.gz
-Source1:        https://www.nominatim.org/data/country_grid.sql.gz
-Source2:        https://www.nominatim.org/data/gb_postcode_data.sql.gz
-Source3:        https://www.nominatim.org/data/us_postcode_data.sql.gz
+# Archive.org is used since data downloads now require a custom user agent
+# https://github.com/osm-search/Nominatim/issues/2929
+Source1:        https://web.archive.org/web/%{data_archive_snapshot}/https://nominatim.org/data/country_grid.sql.gz
+Source2:        https://web.archive.org/web/%{data_archive_snapshot}/https://nominatim.org/data/gb_postcode_data.sql.gz
+Source3:        https://web.archive.org/web/%{data_archive_snapshot}/https://nominatim.org/data/us_postcode_data.sql.gz
 %if %{with tests}
 Source4:        https://download.geofabrik.de/europe/monaco-latest.osm.pbf
 %endif
@@ -63,13 +65,15 @@ BuildRequires:  php-pear
 BuildRequires:  php-pgsql
 BuildRequires:  postgresql%{postgres_version}-devel
 BuildRequires:  proj-devel
+BuildRequires:  pylint
+BuildRequires:  python3-behave
 BuildRequires:  python3-devel
 BuildRequires:  python3-dotenv
 BuildRequires:  python3-jinja2
 BuildRequires:  python3-osmium
 BuildRequires:  python3-pip
-BuildRequires:  python3-psycopg2
 BuildRequires:  python3-psutil
+BuildRequires:  python3-psycopg2
 BuildRequires:  python3-pytest
 BuildRequires:  python3-pytest-cov
 BuildRequires:  python3-pyyaml
@@ -85,9 +89,7 @@ BuildRequires:  postgresql%{postgres_version}-server
 ## BuildRequires:  PHP_CodeSniffer
 ## BuildRequires:  PHPUnit
 ## Python:
-## BuildRequires:  python3-behave
 ## BuildRequires:  python3-pyicu
-## BuildRequires:  python3-pylint
 ## BuildRequires:  python3-pytidylib
 %endif
 

--- a/SPECS/el9/overpass-api.spec
+++ b/SPECS/el9/overpass-api.spec
@@ -13,6 +13,8 @@ License:        Affero GPL v3
 URL:            https://overpass-api.de/
 Source0:        https://dev.overpass-api.de/releases/osm-3s_v%{rpmbuild_version}.tar.gz
 
+Patch0:         overpass-api-environment-settings.patch
+
 BuildRequires:  autoconf
 BuildRequires:  autoconf-archive
 BuildRequires:  automake
@@ -21,8 +23,6 @@ BuildRequires:  expat-devel
 BuildRequires:  lz4-devel
 BuildRequires:  make
 BuildRequires:  zlib-devel
-
-Patch0:         overpass-api-environment-settings.patch
 
 # Replication scripts use wget to retrieve URLs.
 Requires:       wget

--- a/docker-compose.el7.yml
+++ b/docker-compose.el7.yml
@@ -31,6 +31,8 @@ x-rpmbuild:
       image: rpmbuild-mod_tile
       version: &mod_tile_version 0.6.1-3
     nominatim:
+      defines:
+        data_archive_snapshot: 20220420232743
       image: rpmbuild-nominatim
       version: &nominatim_version 4.0.1-2
     nominatim-ui:

--- a/docker-compose.el9.yml
+++ b/docker-compose.el9.yml
@@ -31,6 +31,8 @@ x-rpmbuild:
       image: rpmbuild-mod_tile
       version: &mod_tile_version 0.6.1-3
     nominatim:
+      defines:
+        data_archive_snapshot: 20220420232743
       image: rpmbuild-nominatim
       version: &nominatim_version 4.2.0-1
     nominatim-ui:


### PR DESCRIPTION
Data downloads now require a custom user agent.

### Also:
* Moved `behave` & `pylint` from Nominatim's `requirements.txt` file to the `.spec` file
  * They are now available in EPEL for EL9