### PR TITLE
Use Cython from CRB for Nominatim build (EL9)

### DIFF
--- a/SPECS/el7/nominatim.spec
+++ b/SPECS/el7/nominatim.spec
@@ -147,7 +147,7 @@ export PATH=${HOME}/.local/bin:${PATH}
 %{__cp} -p %{SOURCE1} data/country_osm_grid.sql.gz
 %{__cp} -p %{SOURCE2} %{SOURCE3} data
 
-%{__mkdir_p} build
+%{__mkdir} build
 pushd build
 scl enable rh-php73 '%{cmake3} \
         -DBUILD_API:BOOL=ON \

--- a/SPECS/el7/osrm-backend.spec
+++ b/SPECS/el7/osrm-backend.spec
@@ -53,7 +53,7 @@ This package contains OSRM header files for development purposes.
 
 %prep
 %autosetup -p1
-%{__mkdir_p} build
+%{__mkdir} build
 # Patch CMakeLists.txt:
 #  * Use proper library path (/usr/lib64)
 #  * Relax Lua requirement to 5.1
@@ -92,7 +92,7 @@ popd
 %check
 %if %{with tests}
 npm run nodejs-tests
-%{__mkdir_p} example/build
+%{__mkdir} example/build
 pushd example/build
 export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:%{buildroot}%{_libdir}
 export PKG_CONFIG_PATH=%{buildroot}%{_libdir}/pkgconfig

--- a/SPECS/el9/nominatim-requirements.txt
+++ b/SPECS/el9/nominatim-requirements.txt
@@ -1,4 +1,3 @@
 datrie==0.8.2
-Cython==0.29.32
 pytidylib==0.3.2
 PyICU==2.10.2

--- a/SPECS/el9/nominatim.spec
+++ b/SPECS/el9/nominatim.spec
@@ -67,6 +67,7 @@ BuildRequires:  postgresql%{postgres_version}-devel
 BuildRequires:  proj-devel
 BuildRequires:  pylint
 BuildRequires:  python3-behave
+BuildRequires:  python3-Cython
 BuildRequires:  python3-devel
 BuildRequires:  python3-dotenv
 BuildRequires:  python3-jinja2


### PR DESCRIPTION
In order to simplify things just a bit.
```shell
$ yum -y info python3-Cython
Last metadata expiration check: 0:00:02 ago on Thu Feb  9 22:38:25 2023.
Available Packages
Name         : python3-Cython
Version      : 0.29.22
Release      : 7.el9
Architecture : x86_64
Size         : 2.2 M
Source       : Cython-0.29.22-7.el9.src.rpm
Repository   : crb
Summary      : Language for writing Python extension modules
URL          : http://www.cython.org
License      : ASL 2.0
Description  : The Cython language makes writing C extensions for the Python language as easy
             : as Python itself. Cython is a source code translator based on Pyrex,
             : but supports more cutting edge functionality and optimizations.
             :
             : The Cython language is a superset of the Python language (almost all Python
             : code is also valid Cython code), but Cython additionally supports optional
             : static typing to natively call C functions, operate with C++ classes and
             : declare fast C types on variables and class attributes.
             : This allows the compiler to generate very efficient C code from Cython code.
             :
             : This makes Cython the ideal language for writing glue code for external C/C++
             : libraries, and for fast C modules that speed up the execution of Python code.
```