### PR TITLE
Upgrade nominatim from v4.0.1 to v4.0.2 (EL7) & from v4.2.0 to v4.2.1 (EL9)

### DIFF
--- a/SPECS/el7/nominatim.spec
+++ b/SPECS/el7/nominatim.spec
@@ -147,7 +147,7 @@ export PATH=${HOME}/.local/bin:${PATH}
 %{__cp} -p %{SOURCE1} data/country_osm_grid.sql.gz
 %{__cp} -p %{SOURCE2} %{SOURCE3} data
 
-%{__mkdir_p} build
+%{__mkdir} build
 pushd build
 scl enable rh-php73 '%{cmake3} \
         -DBUILD_API:BOOL=ON \

--- a/SPECS/el7/osrm-backend.spec
+++ b/SPECS/el7/osrm-backend.spec
@@ -53,7 +53,7 @@ This package contains OSRM header files for development purposes.
 
 %prep
 %autosetup -p1
-%{__mkdir_p} build
+%{__mkdir} build
 # Patch CMakeLists.txt:
 #  * Use proper library path (/usr/lib64)
 #  * Relax Lua requirement to 5.1
@@ -92,7 +92,7 @@ popd
 %check
 %if %{with tests}
 npm run nodejs-tests
-%{__mkdir_p} example/build
+%{__mkdir} example/build
 pushd example/build
 export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:%{buildroot}%{_libdir}
 export PKG_CONFIG_PATH=%{buildroot}%{_libdir}/pkgconfig

--- a/SPECS/el9/nominatim-requirements.txt
+++ b/SPECS/el9/nominatim-requirements.txt
@@ -1,4 +1,3 @@
 datrie==0.8.2
-Cython==0.29.32
 pytidylib==0.3.2
 PyICU==2.10.2

--- a/SPECS/el9/nominatim.spec
+++ b/SPECS/el9/nominatim.spec
@@ -67,6 +67,7 @@ BuildRequires:  postgresql%{postgres_version}-devel
 BuildRequires:  proj-devel
 BuildRequires:  pylint
 BuildRequires:  python3-behave
+BuildRequires:  python3-Cython
 BuildRequires:  python3-devel
 BuildRequires:  python3-dotenv
 BuildRequires:  python3-jinja2

--- a/docker-compose.el7.yml
+++ b/docker-compose.el7.yml
@@ -32,9 +32,9 @@ x-rpmbuild:
       version: &mod_tile_version 0.6.1-3
     nominatim:
       defines:
-        data_archive_snapshot: 20220420232743
+        data_archive_snapshot: 20230208112358
       image: rpmbuild-nominatim
-      version: &nominatim_version 4.0.1-2
+      version: &nominatim_version 4.0.2-1
     nominatim-ui:
       image: rpmbuild-nominatim-ui
       version: &nominatim_ui_version 3.2.8-1

--- a/docker-compose.el9.yml
+++ b/docker-compose.el9.yml
@@ -32,9 +32,9 @@ x-rpmbuild:
       version: &mod_tile_version 0.6.1-3
     nominatim:
       defines:
-        data_archive_snapshot: 20220420232743
+        data_archive_snapshot: 20230208112358
       image: rpmbuild-nominatim
-      version: &nominatim_version 4.2.0-1
+      version: &nominatim_version 4.2.1-1
     nominatim-ui:
       image: rpmbuild-nominatim-ui
       version: &nominatim_ui_version 3.2.10-1


### PR DESCRIPTION
This fixes a potential XSS vulnerability in the HTML debug view.

https://github.com/osm-search/Nominatim/releases

As well as using `python3-Cython` from `CRB` rather than via `pip3`