### PR TITLE
Overpass API 0.7.59.2

### DIFF
--- a/SOURCES/el9/overpass-api-environment-settings.patch
+++ b/SOURCES/el9/overpass-api-environment-settings.patch
@@ -1,5 +1,5 @@
 diff --git a/overpass_api/core/settings.cc b/overpass_api/core/settings.cc
-index 81a1d2a2..320c5d59 100644
+index bd3edf1a..d6d46643 100644
 --- a/overpass_api/core/settings.cc
 +++ b/overpass_api/core/settings.cc
 @@ -24,6 +24,7 @@
@@ -12,8 +12,8 @@ index 81a1d2a2..320c5d59 100644
  #include <sstream>
 @@ -101,6 +102,8 @@ Basic_Settings::Basic_Settings()
    shared_name_base("/osm3s_v0.7.58"),
-   version("0.7.59.1"),
-   source_hash("2a9d9642eaa7775a716166f1b9fc564e60c06b84"),
+   version("0.7.59.2"),
+   source_hash("0994154d21eadba1b1e44cecbf9bfc604f244de9"),
 +  enclave(getenv("OVERPASS_API_ENCLAVE") ? getenv("OVERPASS_API_ENCLAVE") : "www.openstreetmap.org"),
 +  generator_note(getenv("OVERPASS_API_GENERATOR_NOTE") ? getenv("OVERPASS_API_GENERATOR_NOTE") : ""),
  #ifdef HAVE_LZ4

--- a/docker-compose.el9.yml
+++ b/docker-compose.el9.yml
@@ -50,7 +50,7 @@ x-rpmbuild:
       version: &osrm_frontend_version 2021.9.30-1
     overpass-api:
       image: rpmbuild-overpass-api
-      version: &overpass_api_version 0.7.59.1-1
+      version: &overpass_api_version 0.7.59.2-1
     taginfo:
       defines:
         abseil_git_ref: 384a25d5e19228ceb7641676aefd58c4ca7a9568


### PR DESCRIPTION
Upgrade Overpass API to 0.7.59.2; [the minor changes since 0.7.59.1](https://github.com/drolbr/Overpass-API/compare/2ce661ef49a5ae9264b630f57c54f376e503f98e..7cc7a2b6ea318cf7545435fd4bc8b456cc7f7d83).