### PR TITLE
Upgrade Overpass API from v0.7.59.2 to v0.7.59.3 (EL9)

### DIFF
--- a/SOURCES/el9/overpass-api-environment-settings.patch
+++ b/SOURCES/el9/overpass-api-environment-settings.patch
@@ -12,8 +12,8 @@ index bd3edf1a..d6d46643 100644
  #include <sstream>
 @@ -101,6 +102,8 @@ Basic_Settings::Basic_Settings()
    shared_name_base("/osm3s_v0.7.58"),
-   version("0.7.59.2"),
-   source_hash("0994154d21eadba1b1e44cecbf9bfc604f244de9"),
+   version("0.7.59.3"),
+   source_hash("7cc7a2b6ea318cf7545435fd4bc8b456cc7f7d83"),
 +  enclave(getenv("OVERPASS_API_ENCLAVE") ? getenv("OVERPASS_API_ENCLAVE") : "www.openstreetmap.org"),
 +  generator_note(getenv("OVERPASS_API_GENERATOR_NOTE") ? getenv("OVERPASS_API_GENERATOR_NOTE") : ""),
  #ifdef HAVE_LZ4

--- a/docker-compose.el9.yml
+++ b/docker-compose.el9.yml
@@ -50,7 +50,7 @@ x-rpmbuild:
       version: &osrm_frontend_version 2021.9.30-1
     overpass-api:
       image: rpmbuild-overpass-api
-      version: &overpass_api_version 0.7.59.2-1
+      version: &overpass_api_version 0.7.59.3-1
     taginfo:
       defines:
         abseil_git_ref: 384a25d5e19228ceb7641676aefd58c4ca7a9568


### PR DESCRIPTION
Doesn't seem like a big update really:
```diff
diff '--color=auto' -r osm-3s_v0.7.59.2/bin/fetch_osc.sh osm-3s_v0.7.59.3/bin/fetch_osc.sh
40a41,55
> EXEC_DIR="$(dirname $0)/"
> if [[ ! "${EXEC_DIR:0:1}" == "/" ]]; then
> {
>   EXEC_DIR="$(pwd)/$EXEC_DIR"
> }; fi
> 
> DB_DIR="$($EXEC_DIR/dispatcher --show-dir)"
> if [[ "$REPLICATE_ID" == "auto" ]]; then
>   if [[ ! -s "$DB_DIR/replicate_id" ]]; then
>     echo "$DB_DIR/replicate_id does not exist and start set to auto"
>     exit 1
>   fi
>   REPLICATE_ID=$(($(cat $DB_DIR/replicate_id) + 0))
> fi
> 
diff '--color=auto' -r osm-3s_v0.7.59.2/configure osm-3s_v0.7.59.3/configure
3c3
< # Generated by GNU Autoconf 2.69 for OverpassAPI 0.7.59.2.
---
> # Generated by GNU Autoconf 2.69 for OverpassAPI 0.7.59.3.
593,594c593,594
< PACKAGE_VERSION='0.7.59.2'
< PACKAGE_STRING='OverpassAPI 0.7.59.2'
---
> PACKAGE_VERSION='0.7.59.3'
> PACKAGE_STRING='OverpassAPI 0.7.59.3'
1342c1342
< \`configure' configures OverpassAPI 0.7.59.2 to adapt to many kinds of systems.
---
> \`configure' configures OverpassAPI 0.7.59.3 to adapt to many kinds of systems.
1413c1413
<      short | recursive ) echo "Configuration of OverpassAPI 0.7.59.2:";;
---
>      short | recursive ) echo "Configuration of OverpassAPI 0.7.59.3:";;
1528c1528
< OverpassAPI configure 0.7.59.2
---
> OverpassAPI configure 0.7.59.3
2072c2072
< It was created by OverpassAPI $as_me 0.7.59.2, which was
---
> It was created by OverpassAPI $as_me 0.7.59.3, which was
2942c2942
<  VERSION='0.7.59.2'
---
>  VERSION='0.7.59.3'
18777c18777
< This file was extended by OverpassAPI $as_me 0.7.59.2, which was
---
> This file was extended by OverpassAPI $as_me 0.7.59.3, which was
18843c18843
< OverpassAPI config.status 0.7.59.2
---
> OverpassAPI config.status 0.7.59.3
diff '--color=auto' -r osm-3s_v0.7.59.2/configure.ac osm-3s_v0.7.59.3/configure.ac
5c5
< AC_INIT([OverpassAPI], [0.7.59.2], [roland@olbricht.nrw])
---
> AC_INIT([OverpassAPI], [0.7.59.3], [roland@olbricht.nrw])
diff '--color=auto' -r osm-3s_v0.7.59.2/Makefile.am osm-3s_v0.7.59.3/Makefile.am
213c213
< distdir = osm-3s_v0.7.59.2
---
> distdir = osm-3s_v0.7.59.3
diff '--color=auto' -r osm-3s_v0.7.59.2/Makefile.in osm-3s_v0.7.59.3/Makefile.in
930c930
< distdir = osm-3s_v0.7.59.2
---
> distdir = osm-3s_v0.7.59.3
diff '--color=auto' -r osm-3s_v0.7.59.2/overpass_api/core/settings.cc osm-3s_v0.7.59.3/overpass_api/core/settings.cc
102,103c102,103
<   version("0.7.59.2"),
<   source_hash("0994154d21eadba1b1e44cecbf9bfc604f244de9"),
---
>   version("0.7.59.3"),
>   source_hash("7cc7a2b6ea318cf7545435fd4bc8b456cc7f7d83"),
```