### PR TITLE
Upgrade Overpass API to 0.7.60.2.

### DIFF
--- a/SOURCES/el9/overpass-api-environment-settings.patch
+++ b/SOURCES/el9/overpass-api-environment-settings.patch
@@ -12,8 +12,8 @@ index bd3edf1a..d6d46643 100644
  #include <sstream>
 @@ -101,6 +102,8 @@ Basic_Settings::Basic_Settings()
    shared_name_base("/osm3s_v0.7.58"),
-   version("0.7.59.4"),
-   source_hash("36d058c8b6fd6770f32b1738ef20d2a31f49672a"),
+   version("0.7.60.2"),
+   source_hash("e4cf9f7aa6b79ebad3236facee3ea78a19d109b0"),
 +  enclave(getenv("OVERPASS_API_ENCLAVE") ? getenv("OVERPASS_API_ENCLAVE") : "www.openstreetmap.org"),
 +  generator_note(getenv("OVERPASS_API_GENERATOR_NOTE") ? getenv("OVERPASS_API_GENERATOR_NOTE") : ""),
  #ifdef HAVE_LZ4

--- a/docker-compose.el9.yml
+++ b/docker-compose.el9.yml
@@ -50,7 +50,7 @@ x-rpmbuild:
       version: &osrm_frontend_version 2021.9.30-1
     overpass-api:
       image: rpmbuild-overpass-api
-      version: &overpass_api_version 0.7.59.4-1
+      version: &overpass_api_version 0.7.60.2-1
     taginfo:
       defines:
         abseil_git_ref: 384a25d5e19228ceb7641676aefd58c4ca7a9568


### PR DESCRIPTION
There are some larger differences this time; we'll want to test this on databases created with 0.7.59.x before merge.