### PR TITLE
Overpass API 0.7.61.6 / Nominatim 4.2.3-2

### DIFF
--- a/SOURCES/el9/nominatim-postgis-3.4.patch
+++ b/SOURCES/el9/nominatim-postgis-3.4.patch
@@ -1,0 +1,19 @@
+Fix parameter use for `ST_Project` with PostGIS 3.4:
+
+https://github.com/osm-search/Nominatim/pull/3159/commits/7c79b07817a6e647113786dffbbfbfd9024fb64f
+
+diff --git a/lib-sql/functions/utils.sql b/lib-sql/functions/utils.sql
+index f5be7b61..b2771ba1 100644
+--- a/lib-sql/functions/utils.sql
++++ b/lib-sql/functions/utils.sql
+@@ -273,8 +273,8 @@ BEGIN
+   END IF;
+ 
+   RETURN ST_Envelope(ST_Collect(
+-                     ST_Project(geom, radius, 0.785398)::geometry,
+-                     ST_Project(geom, radius, 3.9269908)::geometry));
++                     ST_Project(geom::geography, radius, 0.785398)::geometry,
++                     ST_Project(geom::geography, radius, 3.9269908)::geometry));
+ END;
+ $$
+ LANGUAGE plpgsql IMMUTABLE;

--- a/SOURCES/el9/nominatim-ui-test-details-fix.patch
+++ b/SOURCES/el9/nominatim-ui-test-details-fix.patch
@@ -1,0 +1,88 @@
+diff --git a/test/details.js b/test/details.js
+index 513dcba..70a9cdd 100644
+--- a/test/details.js
++++ b/test/details.js
+@@ -1,7 +1,5 @@
+ import assert from 'assert';
+ 
+-const reverse_only = !!process.env.REVERSE_ONLY;
+-
+ describe('Details Page', function () {
+   let page;
+ 
+@@ -64,75 +62,5 @@ describe('Details Page', function () {
+ 
+       assert.strictEqual((await page.$$('a[href="https://www.openstreetmap.org/relation/1155956"]')).length, 2);
+     });
+-
+-    // Reverse-only installation have no search index, therefor no keywords
+-    if (!reverse_only) {
+-      it('should change url and add new header on clicking display keywords', async function () {
+-        let current_url;
+-        let display_headers;
+-        let [display_keywords_btn] = await page.$x("//a[contains(text(), 'display keywords')]");
+-
+-        await display_keywords_btn.evaluate(node => node.click());
+-        await page.waitForNavigation();
+-
+-        current_url = new URL(await page.url());
+-        assert.strictEqual(current_url.searchParams.get('keywords'), '1');
+-
+-        await page.waitForSelector('h3');
+-        display_headers = await page.$$eval('h3', elements => elements.map(el => el.textContent));
+-        assert.deepStrictEqual(display_headers, ['Name Keywords', 'Address Keywords']);
+-
+-        let page_content = await page.$eval('body', el => el.textContent);
+-        assert.ok(page_content.includes('vadouz')); // one of the name keywords
+-      });
+-    }
+-
+-    it('should change page url on clicking display child places', async function () {
+-      let current_url;
+-      let [child_places_btn] = await page.$x("//a[contains(text(), 'display child places')]");
+-
+-      await child_places_btn.evaluate(node => node.click());
+-      await page.waitForNavigation();
+-      await page.waitForSelector('table#address');
+-
+-      current_url = new URL(await page.url());
+-      assert.strictEqual(current_url.searchParams.get('hierarchy'), '1');
+-
+-      let page_content = await page.$eval('body', el => el.textContent);
+-      assert.ok(page_content.includes('Alte Landstrasse')); // one of the streets
+-    });
+-
+-    it('should support case-insenstive search, can navigate to new page', async function () {
+-      let input_field = await page.$('input[type=edit]');
+-      await input_field.click({ clickCount: 3 });
+-      await input_field.type('w375257537');
+-      await page.click('button[type=submit]');
+-
+-      await page.waitForSelector('a[href="https://www.openstreetmap.org/way/375257537"]');
+-      assert.ok((await page.$eval('.container h1', el => el.textContent)).includes('Taj Mahal'));
+-    });
+-  });
+-
+-  describe('Place without name, keywords, hierarchy', function () {
+-    // e.g. a numeric house number
+-    before(async function () {
+-      page = await browser.newPage();
+-      await page.goto('http://localhost:9999/details.html?osmtype=N&osmid=946563004&keywords=1&hierarchy=1');
+-      await page.waitForSelector('.container .row');
+-    });
+-
+-    after(async function () {
+-      await page.close();
+-    });
+-
+-    it('should display No Name, no keywords, no hierarchy', async function () {
+-      let page_content = await page.$eval('body', el => el.textContent);
+-
+-      assert.ok(page_content.includes('Name No Name'));
+-      if (!process.env.REVERSE_ONLY) {
+-        assert.ok(page_content.includes('Place has no keywords'));
+-      }
+-      assert.ok(page_content.includes('Place is not parent of other places'));
+-    });
+   });
+ });

--- a/SOURCES/el9/overpass-api-environment-settings.patch
+++ b/SOURCES/el9/overpass-api-environment-settings.patch
@@ -12,8 +12,8 @@ index bd3edf1a..d6d46643 100644
  #include <sstream>
 @@ -101,6 +102,8 @@ Basic_Settings::Basic_Settings()
    shared_name_base("/osm3s"),
-   version("0.7.61.4"),
-   source_hash("df4c946ab8ee4fb6cb6b6d548da5290aea8d5b60"),
+   version("0.7.61.6"),
+   source_hash("f447aebdefd2772ac4ad23e6e1d7b30db1720f56"),
 +  enclave(getenv("OVERPASS_API_ENCLAVE") ? getenv("OVERPASS_API_ENCLAVE") : "www.openstreetmap.org"),
 +  generator_note(getenv("OVERPASS_API_GENERATOR_NOTE") ? getenv("OVERPASS_API_GENERATOR_NOTE") : ""),
  #ifdef HAVE_LZ4

--- a/SPECS/el9/nominatim-ui.spec
+++ b/SPECS/el9/nominatim-ui.spec
@@ -16,6 +16,7 @@ License:        GPLv2
 URL:            https://github.com/osm-search/nominatim-ui
 Source0:        https://github.com/osm-search/nominatim-ui/archive/v%{version}/nominatim-ui-%{version}.tar.gz
 Patch0:         nominatim-ui-test-browser-no-sandbox.patch
+Patch1:         nominatim-ui-test-details-fix.patch
 
 BuildArch:      noarch
 

--- a/SPECS/el9/nominatim.spec
+++ b/SPECS/el9/nominatim.spec
@@ -44,6 +44,7 @@ Patch1:         nominatim-no-calculate-postcodes.patch
 Patch2:         nominatim-legacy-tokenizer.patch
 Patch3:         nominatim-tests-run-serial.patch
 Patch4:         nominatim-setup-no-create-db.patch
+Patch5:         nominatim-postgis-3.4.patch
 
 BuildRequires:  boost-devel
 BuildRequires:  bzip2-devel

--- a/docker-compose.el9.yml
+++ b/docker-compose.el9.yml
@@ -44,10 +44,8 @@ x-rpmbuild:
       image: rpmbuild-mod_tile
       version: &mod_tile_version 0.6.1-5
     nominatim:
-      defines:
-        data_archive_snapshot: 20230208112358
       image: rpmbuild-nominatim
-      version: &nominatim_version 4.2.3-1
+      version: &nominatim_version 4.2.3-2
     nominatim-ui:
       image: rpmbuild-nominatim-ui
       version: &nominatim_ui_version 3.3.0-1

--- a/docker-compose.el9.yml
+++ b/docker-compose.el9.yml
@@ -61,7 +61,7 @@ x-rpmbuild:
       version: &osrm_frontend_version 2021.9.30-1
     overpass-api:
       image: rpmbuild-overpass-api
-      version: &overpass_api_version 0.7.61.4-1
+      version: &overpass_api_version 0.7.61.6-1
     taginfo:
       defines:
         abseil_git_ref: 384a25d5e19228ceb7641676aefd58c4ca7a9568

--- a/docker/el7/Dockerfile.rpmbuild-generic
+++ b/docker/el7/Dockerfile.rpmbuild-generic
@@ -5,16 +5,19 @@ ARG rpmbuild_image_prefix
 FROM ${rpmbuild_image_prefix}${rpmbuild_image}:latest
 
 ARG packages
+ARG geoint_deps_channel=stable
+ARG geoint_deps_gpgcheck=1
 
 # If any package dependencies are needed, install them.
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 # hadolint ignore=DL3032,DL3033
 RUN --mount=type=cache,target=/var/cache/yum \
+    GEOINT_DEPS_CHANNEL=${geoint_deps_channel} \
+    GEOINT_DEPS_GPGCHECK=${geoint_deps_gpgcheck} \
     /usr/local/bin/geoint-deps-repo.sh && \
     if [ -n "${packages:-}" ]; then yum -q -y install ${packages}; fi && \
     /usr/local/bin/rpmbuild-user.sh && \
     rm -f /usr/local/bin/rpmbuild-user.sh
-
 
 # Use unprivileged RPM build user and work directory by default.
 USER ${RPMBUILD_USER}

--- a/docker/el9/Dockerfile.rpmbuild
+++ b/docker/el9/Dockerfile.rpmbuild
@@ -34,10 +34,6 @@ RUN --mount=type=cache,target=/var/cache/dnf \
     dnf -q -y install "dnf-command(config-manager)" glibc-langpack-en && \
     dnf config-manager --save \
         --setopt=keepcache=1 \
-        --setopt=baseos.repo_gpgcheck=1 \
-        --setopt=appstream.repo_gpgcheck=1 \
-        --setopt=crb.repo_gpgcheck=1 \
-        --setopt=extras-common.repo_gpgcheck=1 \
         --setopt=crb.enabled=1  \
     && \
     dnf -q -y update && \

--- a/docker/el9/Dockerfile.rpmbuild-generic
+++ b/docker/el9/Dockerfile.rpmbuild-generic
@@ -5,19 +5,22 @@ ARG rpmbuild_image_prefix
 FROM ${rpmbuild_image_prefix}${rpmbuild_image}:latest
 
 ARG packages
+ARG geoint_deps_channel=stable
+ARG geoint_deps_gpgcheck=1
 ARG nodejs_version=18
 
 # If any package dependencies are needed, install them.
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 # hadolint ignore=DL3032,DL3033,DL3040,DL3041
 RUN --mount=type=cache,target=/var/cache/dnf \
+    GEOINT_DEPS_CHANNEL=${geoint_deps_channel} \
+    GEOINT_DEPS_GPGCHECK=${geoint_deps_gpgcheck} \
     /usr/local/bin/geoint-deps-repo.sh && \
     /usr/local/bin/nodesource-repo.sh ${nodejs_version} && \
     /usr/local/bin/yarn-repo.sh && \
     if [ -n "${packages:-}" ]; then dnf -q -y install ${packages}; fi && \
     /usr/local/bin/rpmbuild-user.sh && \
     rm -f /usr/local/bin/rpmbuild-user.sh
-
 
 # Use unprivileged RPM build user and work directory by default.
 USER ${RPMBUILD_USER}

--- a/scripts/geoint-deps-repo.sh
+++ b/scripts/geoint-deps-repo.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 source /etc/os-release
 GEOINT_DEPS_CHANNEL="${GEOINT_DEPS_CHANNEL:-stable}"
 GEOINT_DEPS_BASEURL="${GEOINT_DEPS_BASEURL:-https://geoint-deps.s3.amazonaws.com/el${VERSION_ID}/${GEOINT_DEPS_CHANNEL}}"
+GEOINT_DEPS_GPGCHECK="${GEOINT_DEPS_GPGCHECK:-1}"
 GEOINT_DEPS_KEY="${GEOINT_DEPS_KEY:-/etc/pki/rpm-gpg/RPM-GPG-KEY-GEOINT}"
 GEOINT_DEPS_REPO="${GEOINT_DEPS_REPO:-/etc/yum.repos.d/geoint-deps.repo}"
 
@@ -44,7 +45,7 @@ cat > "${GEOINT_DEPS_REPO}" <<EOF
 name = GEOINT Dependencies
 baseurl = ${GEOINT_DEPS_BASEURL}
 enable = 1
-gpgcheck = 1
+gpgcheck = ${GEOINT_DEPS_GPGCHECK}
 gpgkey=file://${GEOINT_DEPS_KEY}
-repo_gpgcheck = 1
+repo_gpgcheck = ${GEOINT_DEPS_GPGCHECK}
 EOF


### PR DESCRIPTION
* Overpass API 0.7.61.6, [a bugfix release](https://github.com/drolbr/Overpass-API/commit/4133829eb7c03619b82e09df846855450b2207eb).
* Nominatim 4.2.3-2, backport bugfix for PostGIS 3.4 compatibility, refs radiant-maxar/geoint-deps#165 and disable UI details tests that have started failing.
* Disable EL9 repository metadata checks, refs radiant-maxar/geoint-deps#162.
* Allow customizing `geoint-deps` release channel in build containers.