### PR TITLE
Overpass API to 0.7.61.8

### DIFF
--- a/SOURCES/el9/overpass-api-environment-settings.patch
+++ b/SOURCES/el9/overpass-api-environment-settings.patch
@@ -12,8 +12,8 @@ index bd3edf1a..d6d46643 100644
  #include <sstream>
 @@ -101,6 +102,8 @@ Basic_Settings::Basic_Settings()
    shared_name_base("/osm3s"),
-   version("0.7.61.6"),
-   source_hash("f447aebdefd2772ac4ad23e6e1d7b30db1720f56"),
+   version("0.7.61.8"),
+   source_hash("b1080abdab2cc256ca324ff29df3e1ba3861bae3"),
 +  enclave(getenv("OVERPASS_API_ENCLAVE") ? getenv("OVERPASS_API_ENCLAVE") : "www.openstreetmap.org"),
 +  generator_note(getenv("OVERPASS_API_GENERATOR_NOTE") ? getenv("OVERPASS_API_GENERATOR_NOTE") : ""),
  #ifdef HAVE_LZ4

--- a/docker-compose.el9.yml
+++ b/docker-compose.el9.yml
@@ -59,7 +59,7 @@ x-rpmbuild:
       version: &osrm_frontend_version 2023.8.19-1
     overpass-api:
       image: rpmbuild-overpass-api
-      version: &overpass_api_version 0.7.61.6-1
+      version: &overpass_api_version 0.7.61.8-1
     taginfo:
       defines:
         abseil_git_ref: 384a25d5e19228ceb7641676aefd58c4ca7a9568


### PR DESCRIPTION
Extremely minor changes from the diff I generated -- basically just modifying `template_db/file_tools.cc` to add:

```cpp
#include <cstdint>
``` 