### PR TITLE
TagInfo 2023.10.05

### DIFF
--- a/SOURCES/el7/taginfo-disable-source-refresh.patch
+++ b/SOURCES/el7/taginfo-disable-source-refresh.patch
@@ -1,0 +1,15 @@
+diff --git a/sources/update_all.sh b/sources/update_all.sh
+index f40dfdf..6f3ef41 100755
+--- a/sources/update_all.sh
++++ b/sources/update_all.sh
+@@ -45,7 +45,9 @@ download_source() {
+     print_message "Downloading and uncompressing $source..."
+ 
+     mkdir -p "$DATADIR/$source"
+-    run_exe curl --silent --fail --output "$DATADIR/download/taginfo-$source.db.bz2" --time-cond "$DATADIR/download/taginfo-$source.db.bz2" "https://taginfo.openstreetmap.org/download/taginfo-$source.db.bz2"
++    if ! test -s "$DATADIR/download/taginfo-$source.db.bz2"; then
++        run_exe curl --silent --fail --output "$DATADIR/download/taginfo-$source.db.bz2" "https://taginfo.openstreetmap.org/download/taginfo-$source.db.bz2"
++    fi
+     run_exe "-l$DATADIR/$source/taginfo-$source.db" "$BZIP_COMMAND" -d -c "$DATADIR/download/taginfo-$source.db.bz2"
+ 
+     print_message "Done."

--- a/SOURCES/el7/taginfo-revert-read-only-dbs.patch
+++ b/SOURCES/el7/taginfo-revert-read-only-dbs.patch
@@ -1,0 +1,88 @@
+Reverts https://github.com/taginfo/taginfo/commit/6c41ab1391956ae285ffc4085a855ffaa64cb30f.
+
+diff --git a/sources/master/history_update.sql b/sources/master/history_update.sql
+index 632c88c..7fc37e0 100644
+--- a/sources/master/history_update.sql
++++ b/sources/master/history_update.sql
+@@ -6,7 +6,7 @@
+ --
+ -- ============================================================================
+ 
+-ATTACH DATABASE 'file:__DIR__/taginfo-master.db?mode=ro' AS master;
++ATTACH DATABASE '__DIR__/taginfo-master.db' AS master;
+ 
+ INSERT INTO history_stats (udate, key, value) SELECT substr(datetime('now'), 1, 10), key, value FROM master.master_stats;
+ 
+diff --git a/sources/master/master-chronology.sql b/sources/master/master-chronology.sql
+index c8eab30..f276407 100644
+--- a/sources/master/master-chronology.sql
++++ b/sources/master/master-chronology.sql
+@@ -6,7 +6,7 @@
+ --
+ -- ============================================================================
+ 
+-ATTACH DATABASE 'file:__DIR__/chronology/taginfo-chronology.db?mode=ro' AS chronology;
++ATTACH DATABASE '__DIR__/chronology/taginfo-chronology.db' AS chronology;
+ 
+ -- ============================================================================
+ 
+diff --git a/sources/master/master-wikidata.sql b/sources/master/master-wikidata.sql
+index d4fd55a..3edf003 100644
+--- a/sources/master/master-wikidata.sql
++++ b/sources/master/master-wikidata.sql
+@@ -6,7 +6,7 @@
+ --
+ -- ============================================================================
+ 
+-ATTACH DATABASE 'file:__DIR__/wikidata/taginfo-wikidata.db?mode=ro' AS wikidata;
++ATTACH DATABASE '__DIR__/wikidata/taginfo-wikidata.db' AS wikidata;
+ 
+ -- ============================================================================
+ 
+diff --git a/sources/master/master.sql b/sources/master/master.sql
+index 2e0374c..931cb8c 100644
+--- a/sources/master/master.sql
++++ b/sources/master/master.sql
+@@ -8,10 +8,10 @@
+ 
+ -- ============================================================================
+ 
+-ATTACH DATABASE '__DIR__/db/taginfo-db.db'                            AS db;
+-ATTACH DATABASE 'file:__DIR__/wiki/taginfo-wiki.db?mode=ro'           AS wiki;
+-ATTACH DATABASE 'file:__DIR__/languages/taginfo-languages.db?mode=ro' AS languages;
+-ATTACH DATABASE 'file:__DIR__/projects/taginfo-projects.db?mode=ro'   AS projects;
++ATTACH DATABASE '__DIR__/db/taginfo-db.db'               AS db;
++ATTACH DATABASE '__DIR__/wiki/taginfo-wiki.db'           AS wiki;
++ATTACH DATABASE '__DIR__/languages/taginfo-languages.db' AS languages;
++ATTACH DATABASE '__DIR__/projects/taginfo-projects.db'   AS projects;
+ 
+ -- ============================================================================
+ 
+diff --git a/sources/master/selection.sql b/sources/master/selection.sql
+index 0eb3268..430f3e8 100644
+--- a/sources/master/selection.sql
++++ b/sources/master/selection.sql
+@@ -11,8 +11,8 @@
+ --
+ -- ============================================================================
+ 
+-ATTACH DATABASE 'file:__DIR__/db/taginfo-db.db?mode=ro'     AS db;
+-ATTACH DATABASE 'file:__DIR__/wiki/taginfo-wiki.db?mode=ro' AS wiki;
++ATTACH DATABASE '__DIR__/db/taginfo-db.db'     AS db;
++ATTACH DATABASE '__DIR__/wiki/taginfo-wiki.db' AS wiki;
+ 
+ -- ============================================================================
+ 
+diff --git a/web/lib/sql.rb b/web/lib/sql.rb
+index 0d411b9..c1a311a 100644
+--- a/web/lib/sql.rb
++++ b/web/lib/sql.rb
+@@ -26,7 +26,7 @@ module SQL
+         end
+ 
+         def attach_source(filename, name)
+-            @db.execute('ATTACH DATABASE ? AS ?', "file:#{ @dir }/#{ filename }?mode=ro", name)
++            @db.execute('ATTACH DATABASE ? AS ?', "#{ @dir }/#{ filename }", name)
+             @db.execute("PRAGMA #{ name }.journal_mode = OFF")
+         end
+ 

--- a/SOURCES/el9/taginfo-disable-source-refresh.patch
+++ b/SOURCES/el9/taginfo-disable-source-refresh.patch
@@ -1,0 +1,15 @@
+diff --git a/sources/update_all.sh b/sources/update_all.sh
+index f40dfdf..6f3ef41 100755
+--- a/sources/update_all.sh
++++ b/sources/update_all.sh
+@@ -45,7 +45,9 @@ download_source() {
+     print_message "Downloading and uncompressing $source..."
+ 
+     mkdir -p "$DATADIR/$source"
+-    run_exe curl --silent --fail --output "$DATADIR/download/taginfo-$source.db.bz2" --time-cond "$DATADIR/download/taginfo-$source.db.bz2" "https://taginfo.openstreetmap.org/download/taginfo-$source.db.bz2"
++    if ! test -s "$DATADIR/download/taginfo-$source.db.bz2"; then
++        run_exe curl --silent --fail --output "$DATADIR/download/taginfo-$source.db.bz2" "https://taginfo.openstreetmap.org/download/taginfo-$source.db.bz2"
++    fi
+     run_exe "-l$DATADIR/$source/taginfo-$source.db" "$BZIP_COMMAND" -d -c "$DATADIR/download/taginfo-$source.db.bz2"
+ 
+     print_message "Done."

--- a/SOURCES/el9/taginfo-revert-read-only-dbs.patch
+++ b/SOURCES/el9/taginfo-revert-read-only-dbs.patch
@@ -1,0 +1,88 @@
+Reverts https://github.com/taginfo/taginfo/commit/6c41ab1391956ae285ffc4085a855ffaa64cb30f.
+
+diff --git a/sources/master/history_update.sql b/sources/master/history_update.sql
+index 632c88c..7fc37e0 100644
+--- a/sources/master/history_update.sql
++++ b/sources/master/history_update.sql
+@@ -6,7 +6,7 @@
+ --
+ -- ============================================================================
+ 
+-ATTACH DATABASE 'file:__DIR__/taginfo-master.db?mode=ro' AS master;
++ATTACH DATABASE '__DIR__/taginfo-master.db' AS master;
+ 
+ INSERT INTO history_stats (udate, key, value) SELECT substr(datetime('now'), 1, 10), key, value FROM master.master_stats;
+ 
+diff --git a/sources/master/master-chronology.sql b/sources/master/master-chronology.sql
+index c8eab30..f276407 100644
+--- a/sources/master/master-chronology.sql
++++ b/sources/master/master-chronology.sql
+@@ -6,7 +6,7 @@
+ --
+ -- ============================================================================
+ 
+-ATTACH DATABASE 'file:__DIR__/chronology/taginfo-chronology.db?mode=ro' AS chronology;
++ATTACH DATABASE '__DIR__/chronology/taginfo-chronology.db' AS chronology;
+ 
+ -- ============================================================================
+ 
+diff --git a/sources/master/master-wikidata.sql b/sources/master/master-wikidata.sql
+index d4fd55a..3edf003 100644
+--- a/sources/master/master-wikidata.sql
++++ b/sources/master/master-wikidata.sql
+@@ -6,7 +6,7 @@
+ --
+ -- ============================================================================
+ 
+-ATTACH DATABASE 'file:__DIR__/wikidata/taginfo-wikidata.db?mode=ro' AS wikidata;
++ATTACH DATABASE '__DIR__/wikidata/taginfo-wikidata.db' AS wikidata;
+ 
+ -- ============================================================================
+ 
+diff --git a/sources/master/master.sql b/sources/master/master.sql
+index 2e0374c..931cb8c 100644
+--- a/sources/master/master.sql
++++ b/sources/master/master.sql
+@@ -8,10 +8,10 @@
+ 
+ -- ============================================================================
+ 
+-ATTACH DATABASE '__DIR__/db/taginfo-db.db'                            AS db;
+-ATTACH DATABASE 'file:__DIR__/wiki/taginfo-wiki.db?mode=ro'           AS wiki;
+-ATTACH DATABASE 'file:__DIR__/languages/taginfo-languages.db?mode=ro' AS languages;
+-ATTACH DATABASE 'file:__DIR__/projects/taginfo-projects.db?mode=ro'   AS projects;
++ATTACH DATABASE '__DIR__/db/taginfo-db.db'               AS db;
++ATTACH DATABASE '__DIR__/wiki/taginfo-wiki.db'           AS wiki;
++ATTACH DATABASE '__DIR__/languages/taginfo-languages.db' AS languages;
++ATTACH DATABASE '__DIR__/projects/taginfo-projects.db'   AS projects;
+ 
+ -- ============================================================================
+ 
+diff --git a/sources/master/selection.sql b/sources/master/selection.sql
+index 0eb3268..430f3e8 100644
+--- a/sources/master/selection.sql
++++ b/sources/master/selection.sql
+@@ -11,8 +11,8 @@
+ --
+ -- ============================================================================
+ 
+-ATTACH DATABASE 'file:__DIR__/db/taginfo-db.db?mode=ro'     AS db;
+-ATTACH DATABASE 'file:__DIR__/wiki/taginfo-wiki.db?mode=ro' AS wiki;
++ATTACH DATABASE '__DIR__/db/taginfo-db.db'     AS db;
++ATTACH DATABASE '__DIR__/wiki/taginfo-wiki.db' AS wiki;
+ 
+ -- ============================================================================
+ 
+diff --git a/web/lib/sql.rb b/web/lib/sql.rb
+index 0d411b9..c1a311a 100644
+--- a/web/lib/sql.rb
++++ b/web/lib/sql.rb
+@@ -26,7 +26,7 @@ module SQL
+         end
+ 
+         def attach_source(filename, name)
+-            @db.execute('ATTACH DATABASE ? AS ?', "file:#{ @dir }/#{ filename }?mode=ro", name)
++            @db.execute('ATTACH DATABASE ? AS ?', "#{ @dir }/#{ filename }", name)
+             @db.execute("PRAGMA #{ name }.journal_mode = OFF")
+         end
+ 

--- a/SPECS/el7/taginfo.spec
+++ b/SPECS/el7/taginfo.spec
@@ -38,6 +38,7 @@ Patch1:         taginfo-logging.patch
 Patch2:         taginfo-use-bundler.patch
 Patch3:         taginfo-sqlite-enable-loadextension.patch
 Patch4:         taginfo-tools-tests-run-serial.patch
+Patch5:         taginfo-revert-read-only-dbs.patch
 
 BuildRequires:  bzip2-devel
 BuildRequires:  cmake3

--- a/SPECS/el7/taginfo.spec
+++ b/SPECS/el7/taginfo.spec
@@ -37,8 +37,9 @@ Patch0:         taginfo-default-config.patch
 Patch1:         taginfo-logging.patch
 Patch2:         taginfo-use-bundler.patch
 Patch3:         taginfo-sqlite-enable-loadextension.patch
-Patch4:         taginfo-tools-tests-run-serial.patch
-Patch5:         taginfo-revert-read-only-dbs.patch
+Patch4:         taginfo-revert-read-only-dbs.patch
+Patch5:         taginfo-disable-source-refresh.patch
+Patch6:         taginfo-tools-tests-run-serial.patch
 
 BuildRequires:  bzip2-devel
 BuildRequires:  cmake3

--- a/SPECS/el9/taginfo.spec
+++ b/SPECS/el9/taginfo.spec
@@ -36,8 +36,9 @@ Patch0:         taginfo-default-config.patch
 Patch1:         taginfo-logging.patch
 Patch2:         taginfo-use-bundler.patch
 Patch3:         taginfo-sqlite-enable-loadextension.patch
-Patch4:         taginfo-tools-tests-run-serial.patch
-Patch5:         taginfo-revert-read-only-dbs.patch
+Patch4:         taginfo-revert-read-only-dbs.patch
+Patch5:         taginfo-disable-source-refresh.patch
+Patch6:         taginfo-tools-tests-run-serial.patch
 
 BuildRequires:  bzip2-devel
 BuildRequires:  cmake

--- a/SPECS/el9/taginfo.spec
+++ b/SPECS/el9/taginfo.spec
@@ -37,6 +37,7 @@ Patch1:         taginfo-logging.patch
 Patch2:         taginfo-use-bundler.patch
 Patch3:         taginfo-sqlite-enable-loadextension.patch
 Patch4:         taginfo-tools-tests-run-serial.patch
+Patch5:         taginfo-revert-read-only-dbs.patch
 
 BuildRequires:  bzip2-devel
 BuildRequires:  cmake

--- a/docker-compose.el7.yml
+++ b/docker-compose.el7.yml
@@ -52,10 +52,10 @@ x-rpmbuild:
     taginfo:
       defines:
         abseil_git_ref: 384a25d5e19228ceb7641676aefd58c4ca7a9568
-        git_ref: 4fd19892e1acc736ffd0de740fd0c14acbdc76c7
+        git_ref: 4ea603d7d0c121c49b2f92f95c43ee2281258af9
         tools_git_ref: 28264e63a2b3027cec69ae4906ef689029df627b
       image: rpmbuild-taginfo
-      version: &taginfo_version 2023.09.07-1
+      version: &taginfo_version 2023.10.05-1
   service_volumes: &service_volumes
     - ./RPMS:/rpmbuild/RPMS:rw
     - ./SOURCES/el7:/rpmbuild/SOURCES:rw

--- a/docker-compose.el9.yml
+++ b/docker-compose.el9.yml
@@ -63,10 +63,10 @@ x-rpmbuild:
     taginfo:
       defines:
         abseil_git_ref: 384a25d5e19228ceb7641676aefd58c4ca7a9568
-        git_ref: 4fd19892e1acc736ffd0de740fd0c14acbdc76c7
+        git_ref: 4ea603d7d0c121c49b2f92f95c43ee2281258af9
         tools_git_ref: 28264e63a2b3027cec69ae4906ef689029df627b
       image: rpmbuild-taginfo
-      version: &taginfo_version 2023.09.07-1
+      version: &taginfo_version 2023.10.05-1
   service_volumes: &service_volumes
     - ./.cache.el9:/rpmbuild/.cache:rw
     - ./RPMS:/rpmbuild/RPMS:rw


### PR DESCRIPTION
* The `update_all.sh` script will retrieve updated databases from upstream even if they exist on filesystem from `taginfo-data` package.  This presents issues when trying to initialize a deployment using older code as updated databases may have incompatible schemas from previous versions.
* Revert use of SQLite file URIs (and passing read only flags) as this prevented deployments from working properly.